### PR TITLE
Feat: Add `New-AzGuid`

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This is the repository for the AzExpression PowerShell Module, a module that all
 Commands implemented:
 
 - [New-AzUniqueString](./docs/en-US/New-AzUniqueString.md) - Invoke the Azure ARM template function uniqueString() locally in PowerShell
+- [New-AzGuid](./docs/en-US/New-AzGuid.md) - Invoke the Azure ARM template function guid() locally in PowerShell
 
 ## Installation
 

--- a/docs/en-US/New-AzGuid.md
+++ b/docs/en-US/New-AzGuid.md
@@ -59,4 +59,4 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/bicep-functions-string#guid
+[https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/bicep-functions-string#guid](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/bicep-functions-string#guid)

--- a/docs/en-US/New-AzGuid.md
+++ b/docs/en-US/New-AzGuid.md
@@ -1,0 +1,62 @@
+---
+external help file: AzExpression-help.xml
+Module Name: AzExpression
+online version:
+schema: 2.0.0
+---
+
+# New-AzGuid
+
+## SYNOPSIS
+Invoke the Azure ARM template function guid() locally in PowerShell
+
+## SYNTAX
+
+```
+New-AzGuid [-InputStrings] <String[]> [<CommonParameters>]
+```
+
+## DESCRIPTION
+Invoke the Azure ARM template function guid() locally in PowerShell
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> New-AzGuid -InputStrings 'test','value'
+```
+
+Returns the string `95b33d6a-06a0-5961-9b94-a0f6c648352b`
+
+## PARAMETERS
+
+### -InputStrings
+Strings used as a seed to generate a unique string.
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### System.Object
+## NOTES
+
+## RELATED LINKS
+
+https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/bicep-functions-string#guid

--- a/src/AzExpression.psd1
+++ b/src/AzExpression.psd1
@@ -12,7 +12,7 @@
 RootModule = 'AzExpression.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.1.0'
+ModuleVersion = '0.2.0'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()
@@ -69,7 +69,7 @@ RequiredAssemblies = @('./assets/Azure.Deployments.Expression.dll')
 # NestedModules = @()
 
 # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
-FunctionsToExport = @('New-AzUniqueString')
+FunctionsToExport = @('New-AzUniqueString', 'New-AzGuid')
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
 CmdletsToExport = @()
@@ -129,4 +129,3 @@ PrivateData = @{
 # DefaultCommandPrefix = ''
 
 }
-

--- a/src/build.psd1
+++ b/src/build.psd1
@@ -1,9 +1,9 @@
 @{
-    Path = "AzExpression.psd1"
-    OutputDirectory = "..\bin\AzExpression"
-    Prefix = '.\_PrefixCode.ps1'
-    SourceDirectories = 'Public'
-    PublicFilter = 'Public\*.ps1'
+    Path                     = "AzExpression.psd1"
+    OutputDirectory          = "..\bin\AzExpression"
+    Prefix                   = '.\_prefixCode.ps1'
+    SourceDirectories        = 'public'
+    PublicFilter             = 'public\*.ps1'
     VersionedOutputDirectory = $true
-    CopyPaths = @('./assets','../LICENSE','./en-US')
+    CopyPaths                = @('./assets', '../LICENSE', './en-US')
 }

--- a/src/en-US/AzExpression-help.xml
+++ b/src/en-US/AzExpression-help.xml
@@ -2,6 +2,90 @@
 <helpItems schema="maml" xmlns="http://msh">
   <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
     <command:details>
+      <command:name>New-AzGuid</command:name>
+      <command:verb>New</command:verb>
+      <command:noun>AzGuid</command:noun>
+      <maml:description>
+        <maml:para>Invoke the Azure ARM template function guid() locally in PowerShell</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Invoke the Azure ARM template function guid() locally in PowerShell</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem>
+        <maml:name>New-AzGuid</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="0" aliases="none">
+          <maml:name>InputStrings</maml:name>
+          <maml:description>
+            <maml:para>Strings used as a seed to generate a unique string.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="0" aliases="none">
+        <maml:name>InputStrings</maml:name>
+        <maml:description>
+          <maml:para>Strings used as a seed to generate a unique string.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+        <dev:type>
+          <maml:name>String[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>System.Object</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>-------------------------- Example 1 --------------------------</maml:title>
+        <dev:code>PS C:\&gt; New-AzGuid -InputStrings 'test','value'</dev:code>
+        <dev:remarks>
+          <maml:para>Returns the string `95b33d6a-06a0-5961-9b94-a0f6c648352b`</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks>
+      <maml:navigationLink>
+        <maml:linkText>https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/bicep-functions-string#guid</maml:linkText>
+        <maml:uri>https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/bicep-functions-string#guid</maml:uri>
+      </maml:navigationLink>
+    </command:relatedLinks>
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
+    <command:details>
       <command:name>New-AzUniqueString</command:name>
       <command:verb>New</command:verb>
       <command:noun>AzUniqueString</command:noun>

--- a/src/public/New-AzGuid.ps1
+++ b/src/public/New-AzGuid.ps1
@@ -1,0 +1,20 @@
+function New-AzGuid {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory)]
+        [string[]]$InputStrings
+    )
+
+    $parameters = [Azure.Deployments.Expression.Expressions.FunctionArgument[]]::new($InputStrings.Count)
+    for ($i = 0; $i -lt $parameters.Count; $i++) {
+        $parameters[$i] = [Newtonsoft.Json.Linq.JValue]::new($InputStrings[$i])
+    }
+
+    $result = $Script:Functions.EvaluateFunction(
+        "guid",
+        $parameters,
+        [Azure.Deployments.Expression.Expressions.ExpressionEvaluationContext]::new()
+    )
+
+    return $result.ToString()
+}


### PR DESCRIPTION
Exposes the `guid()` function as `New-AzGuid`

Also fixes some case inconsistencies between file names and what's referred to in the `build.psd1` file.

Related issue #1